### PR TITLE
Update Chapter1.ipynb

### DIFF
--- a/Chapters/Chapter1.ipynb
+++ b/Chapters/Chapter1.ipynb
@@ -107,7 +107,7 @@
         "\n",
         "class MyFirstChain(Runnable[int, str]):\n",
         "\n",
-        "   def invoke(self, input: str, config: Optional[RunnableConfig] = None) -> str:\n",
+        "   def invoke(self, input: int, config: Optional[RunnableConfig] = None) -> str:\n",
         "    increment = increment_by_one(input)\n",
         "    return fake_llm(increment)\n"
       ],


### PR DESCRIPTION
The invoke method specifies input: str, but it passes the input directly to increment_x_by_one, which expects an int. 

Fix: Update the invoke method's parameter to input: int